### PR TITLE
Handling USSD starting with #

### DIFF
--- a/lib/ussd_advanced.dart
+++ b/lib/ussd_advanced.dart
@@ -99,13 +99,16 @@ class UssdAdvanced {
 class _CodeAndBody {
   _CodeAndBody(this.code, this.messages);
   _CodeAndBody.fromUssdCode(String _code) {
-    var _removeCode = _code.split('#')[0];
+    var _removeCode = _code.substring(1, _code.length - 1);
+    // var _removeCode = _code.split('#')[0];
     var items = _removeCode.split("*").toList();
 
-    code = '*${items[1]}#';
+    // code = '*${items[1]}#';
+    code = '${_code[0]}${items[0]}#';
 
     if (items.length > 1) {
-      messages = items.sublist(2);
+      // messages = items.sublist(2);
+      messages = items.sublist(1);
     }
   }
   late String code;


### PR DESCRIPTION
This modification enables the project to accept and process USSD codes that start with the # character. Prior to this update, only USSD codes starting with * were considered. Now, the application can correctly interpret USSD codes based on their prefix, improving overall support.